### PR TITLE
Bugfix/exception thrown on validation error

### DIFF
--- a/EventListener/EntityValidatorListener.php
+++ b/EventListener/EntityValidatorListener.php
@@ -6,9 +6,9 @@ namespace HalloVerden\EntityUtilsBundle\EventListener;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\Event\OnFlushEventArgs;
 use Doctrine\ORM\Events;
-use Doctrine\ORM\UnitOfWork;
 use HalloVerden\EntityUtilsBundle\Interfaces\ValidatableEntityInterface;
 use HalloVerden\HttpExceptions\Utility\ValidationException;
+use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
@@ -59,28 +59,33 @@ class EntityValidatorListener implements EventSubscriber {
 
     foreach ($uow->getScheduledEntityInsertions() as $entity) {
       if ($entity instanceof ValidatableEntityInterface) {
-        $this->validateEntity($entity, $uow);
+        $this->validateEntity($entity);
       }
     }
 
     foreach ($uow->getScheduledEntityUpdates() as $entity) {
       if ($entity instanceof ValidatableEntityInterface) {
-        $this->validateEntity($entity, $uow);
+        $this->validateEntity($entity, $uow->getEntityChangeSet($entity));
       }
     }
   }
 
   /**
    * @param ValidatableEntityInterface $entity
-   * @param UnitOfWork                 $uow
+   * @param array|null                 $changeSet
    */
-  private function validateEntity(ValidatableEntityInterface $entity, UnitOfWork $uow): void {
-    $violations = $this->validator->validate($entity, null, $this->validationGroups);
+  private function validateEntity(ValidatableEntityInterface $entity, ?array $changeSet = null): void {
+    if ($changeSet === null) {
+      $violations = $this->validator->validate($entity, null, $this->validationGroups);
+    } else {
+      $violations = new ConstraintViolationList();
+
+      foreach (array_keys($changeSet) as $property) {
+        $violations->addAll($this->validator->validateProperty($entity, $property, $this->validationGroups));
+      }
+    }
 
     if (count($violations) > 0) {
-      // Detach this entity to avoid multiple checks on this entity.
-      $uow->clear($entity);
-
       throw new ValidationException($violations);
     }
   }


### PR DESCRIPTION
only validate properties changed and remove call to clear() since this throws an error.

fixes #5 